### PR TITLE
Prevent faux style application to Analogue font

### DIFF
--- a/src/font.css
+++ b/src/font.css
@@ -6,3 +6,33 @@
   font-weight: normal;
   font-style: normal;
 }
+
+/*
+  The following prevents faux- bold and italic styles from being applied:
+*/
+@font-face {
+  font-family: Analogue;
+  src:
+    url("assets/AnalogueOS-Regular.woff2") format("woff2"),
+    url("assets/AnalogueOS-Regular.woff") format("woff");
+  font-weight: bold;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: Analogue;
+  src:
+    url("assets/AnalogueOS-Regular.woff2") format("woff2"),
+    url("assets/AnalogueOS-Regular.woff") format("woff");
+  font-weight: normal;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: Analogue;
+  src:
+    url("assets/AnalogueOS-Regular.woff2") format("woff2"),
+    url("assets/AnalogueOS-Regular.woff") format("woff");
+  font-weight: bold;
+  font-style: italic;
+}


### PR DESCRIPTION
Analogue font doesn't have bold and italic versions, but when those styles are applied, the browser tries to fake it automatically and applies faux-styles. In the instance of this app, all the headers that use this font become chonky and lose detail. The additions I provided should override those automatic faux-styles.

Unfortunately I couldn't test it with the app itself, cause I wasn't able to build it. Please lmk if it worked.